### PR TITLE
add symlink for Tilix terminal emulator

### DIFF
--- a/Emerald/apps/16/com.gexperts.Tilix.svg
+++ b/Emerald/apps/16/com.gexperts.Tilix.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/Emerald/apps/22/com.gexperts.Tilix.svg
+++ b/Emerald/apps/22/com.gexperts.Tilix.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/Emerald/apps/32/com.gexperts.Tilix.svg
+++ b/Emerald/apps/32/com.gexperts.Tilix.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/Emerald/apps/48/com.gexperts.Tilix.svg
+++ b/Emerald/apps/48/com.gexperts.Tilix.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg


### PR DESCRIPTION
Adds a `com.gexperts.Tilix.svg` symlink within each `apps` subdir, pointing to the existing `utilities-terminal.svg` to provide the terminal icon for [Tilix](https://github.com/gnunn1/tilix).